### PR TITLE
Add Carboncreditcoin (CCC) token to PancakeSwap extended list

### DIFF
--- a/lists/pancakeswap-extended.json
+++ b/lists/pancakeswap-extended.json
@@ -3421,20 +3421,20 @@
       "logoURI": "https://tokens.pancakeswap.finance/images/0xb86AbCb37C3A4B64f74f59301AFF131a1BEcC787.png"
     },
     {
-      "name": "ZOO Crypto World",
-      "symbol": "ZOO",
-      "address": "0x1D229B958D5DDFca92146585a8711aECbE56F095",
-      "chainId": 56,
-      "decimals": 18,
-      "logoURI": "https://tokens.pancakeswap.finance/images/0x1D229B958D5DDFca92146585a8711aECbE56F095.png"
-    },
-    {
-      "name": "LayerZero",
-      "symbol": "ZRO",
-      "address": "0x6985884C4392D348587B19cb9eAAf157F13271cd",
-      "chainId": 56,
-      "decimals": 18,
-      "logoURI": "https://tokens.pancakeswap.finance/images/0x6985884C4392D348587B19cb9eAAf157F13271cd.png"
-    }
-  ]
+  "name": "LayerZero",
+  "symbol": "ZRO",
+  "address": "0x6985884C4392D348587B19cb9eAAf157F13271cd",
+  "chainId": 56,
+  "decimals": 18,
+  "logoURI": "https://tokens.pancakeswap.finance/images/0x6985884C4392D348587B19cb9eAAf157F13271cd.png"
+},
+{
+  "name": "Carboncreditcoin",
+  "symbol": "CCC",
+  "address": "0x0BD1d8ad0fb9435dd23018b2B17b24147D6b2c7E",
+  "chainId": 56,
+  "decimals": 18,
+  "logoURI": "https://green-hidden-cephalopod-725.mypinata.cloud/ipfs/bafkreicsbsbni4ldwrlze4puihinyr3qpq4bka7iandiaeqzpddp3zgcoq"
+}
+]
 }


### PR DESCRIPTION
This PR adds the Carboncreditcoin (CCC Token) to the PancakeSwap extended token list for display on the BSC swap interface.
- Contract Address: 0x0BD1d8ad0fb9435dd23018b2B17b24147D6b2c7E
- Name: Carboncreditcoin
- Symbol: CCC
- Decimals: 18
- Chain: BNB Smart Chain (chainId: 56)
- Logo URI: https://green-hidden-cephalopod-725.mypinata.cloud/ipfs/bafkreicsbsbni4ldwrlze4puihinyr3qpq4bka7iandiaeqzpddp3zgcoq
- Deployer: 0x319Aab2A82E49eE859ba2eCE0aF73eA0676e76e9
- Transaction Hash: 0xefa49f8455cbbd50e9cec65bbddc9e4bd013e2e5e21ff543823ebc6a625e2268
- Ensured valid JSON with correct closing brackets.