### PR TITLE
This PR adds the Carboncreditcoin (CCC Token) to the PancakeSwap extended token list to display its logo on the BSC swap interface.

### DIFF
--- a/lists/pancakeswap-extended.json
+++ b/lists/pancakeswap-extended.json
@@ -3435,6 +3435,14 @@
       "chainId": 56,
       "decimals": 18,
       "logoURI": "https://tokens.pancakeswap.finance/images/0x6985884C4392D348587B19cb9eAAf157F13271cd.png"
-    }
+    },
+    {
+  "name": "Carboncreditcoin",
+  "symbol": "CCC",
+  "address": "0x0BD1d8ad0fb9435dd23018b2B17b24147D6b2c7E",
+  "chainId": 56,
+  "decimals": 18,
+  "logoURI": "https://green-hidden-cephalopod-725.mypinata.cloud/ipfs/bafkreicsbsbni4ldwrlze4puihinyr3qpq4bka7iandiaeqzpddp3zgcoq"
+},
   ]
 }


### PR DESCRIPTION

- Contract Address: 0x0BD1d8ad0fb9435dd23018b2B17b24147D6b2c7E
- Name: Carboncreditcoin
- Symbol: CCC
- Decimals: 18
- Chain: BNB Smart Chain (chainId: 56)
- Logo URI: https://green-hidden-cephalopod-725.mypinata.cloud/ipfs/bafkreicsbsbni4ldwrlze4puihinyr3qpq4bka7iandiaeqzpddp3zgcoq
- Deployer: 0x319Aab2A82E49eE859ba2eCE0aF73eA0676e76e9
- Transaction Hash: 0xefa49f8455cbbd50e9cec65bbddc9e4bd013e2e5e21ff543823ebc6a625e2268
- Fixed replacement error by restoring LayerZero and appending CCC Token.
- Added missing comma before closing bracket for valid JSON.oq